### PR TITLE
Add logging for project branch initialization

### DIFF
--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/EMFStoreController.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/EMFStoreController.java
@@ -35,6 +35,7 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.emfstore.common.ESResourceSetProvider;
@@ -249,9 +250,16 @@ public class EMFStoreController implements IApplication, Runnable {
 					project.getBranches().add(branchInfo);
 					new ResourceHelper(serverSpace).save(project);
 				} else {
-					final String errorMessage = MessageFormat.format(
-						"[EMFStoreController] Could not initiliaze branch because the project has no versions. Project: {0} (ID: {1})", //$NON-NLS-1$
-						project.getProjectName(), project.getProjectId());
+					String errorMessage;
+					if (project.eIsProxy()) {
+						errorMessage = MessageFormat.format(
+							"[EMFStoreController] Could not initiliaze branch because the project is a ProjectHistory-Proxy with ProxyURI: {0}", //$NON-NLS-1$
+							InternalEObject.class.cast(project).eProxyURI());
+					} else {
+						errorMessage = MessageFormat.format(
+							"[EMFStoreController] Could not initiliaze branch because the project has no versions. Project: {0} (ID: {1})", //$NON-NLS-1$
+							project.getProjectName(), project.getProjectId());
+					}
 					ModelUtil.logError(errorMessage);
 					if (exitOnFail) {
 						throw new FatalESException(errorMessage);

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/ServerConfiguration.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/ServerConfiguration.java
@@ -275,6 +275,16 @@ public final class ServerConfiguration {
 	public static final String LOAD_STARTUP_LISTENER_DEFAULT = Boolean.TRUE.toString();
 
 	/**
+	 * Whether the server should exit if there is an error while initializing missing project branches.
+	 */
+	public static final String STARTUP_EXIT_ON_BRANCH_INIT_ERROR = "emfstore.startup.branch.init.exit.on.fail"; //$NON-NLS-1$
+
+	/**
+	 * Default values for {@link #STARTUP_EXIT_ON_BRANCH_INIT_ERROR}.
+	 */
+	public static final String STARTUP_EXIT_ON_BRANCH_INIT_ERROR_DEFAULT = Boolean.TRUE.toString();
+
+	/**
 	 * Property name of accepted client versions. Enter the version's names or
 	 * any, seperate multiple entries with {@link #MULTI_PROPERTY_SEPERATOR}.
 	 */

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/es.properties
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/es.properties
@@ -228,6 +228,13 @@ emfstore.accesscontrol.authentication.ldap.2.base=ou=Personen,ou=IN,o=TUM,c=DE
 emfstore.accesscontrol.authentication.ldap.2.searchdn=uid
 
 
+# Configures the EMFStore controller.
+# Defines whether the EMFStore should exit if initialization of missing branches fails for any project.
+# Options: true or false
+# Default: true
+#
+emfstore.startup.branch.init.exit.on.fail = true
+
 #
 # Plugin configuration.
 #

--- a/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/startup/ServerHrefMigrator.java
+++ b/bundles/org.eclipse.emf.emfstore.server/src/org/eclipse/emf/emfstore/internal/server/startup/ServerHrefMigrator.java
@@ -169,6 +169,7 @@ public class ServerHrefMigrator {
 	}
 
 	private List<String> doMigrate(String serverHome) throws InvocationTargetException {
+		ModelUtil.logInfo("[ServerHrefMigrator] Execute migration for server home: " + serverHome); //$NON-NLS-1$
 		migrateNonContainment(serverHome + STORAGE_USS, "projects", new ServerSpaceRule()); //$NON-NLS-1$
 
 		final File serverHomeFile = new File(serverHome);


### PR DESCRIPTION
- Add logging to the EMFStoreController to be able to track down projects failing branch initialization
- Log proxy URI if the EMFStoreController tries to initialize branches for a ProjectHistory Proxy
- Allow to configure that the server continues to run when branch initialization fails
- Log when the ServerHrefMigrator migrates a server space